### PR TITLE
Support for different statusCode in res.redirect.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,15 @@ function expressCacheOnDemand(hasher) {
 
     patch(res, {
       redirect: function(url) {
+        var status = 302;
+        var url = url;
+
+        if (typeof arguments[0] === 'number') {
+          status = arguments[0];
+          url = arguments[1];
+        }
+
+        _res.redirectStatus = status;
         _res.redirect = url;
         return finish();
       },
@@ -71,7 +80,7 @@ function expressCacheOnDemand(hasher) {
         res.setHeader(key, val);
       });
       if (_res.redirect) {
-        return res.redirect(_res.redirect);
+        return res.redirect(_res.redirectStatus, _res.redirect);
       }
       if (_res.body) {
         return res.send(_res.body);

--- a/index.js
+++ b/index.js
@@ -63,7 +63,6 @@ function expressCacheOnDemand(hasher) {
 
   return function(req, res, next) {
     return codForMiddleware(req, res, next, function(_res) {
-
       // Replay the captured response
       if (_res.statusCode) {
         res.statusCode = _res.statusCode;
@@ -83,6 +82,8 @@ function expressCacheOnDemand(hasher) {
       // We know about ending a request with one of
       // the above three methods. Anything else doesn't
       // make sense with this middleware
+
+      console.log('Attempted Request URL: ' + req.url);
       throw 'cacheOnDemand.middleware does not know how to deliver this response, use the middleware only with routes that end with res.redirect, res.send or res.end';
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-cache-on-demand",
-  "version": "0.1.1",
+  "version": "0.1.11",
   "description": "Express middleware providing on-demand caching in high traffic situations.",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,12 @@ app.get('/welcome', expressCacheOnDemand, function(req, res) {
 app.get('/redirect', expressCacheOnDemand, function(req, res) {
   return res.redirect('/welcome');
 });
+app.get('/redirect-301', expressCacheOnDemand, function(req, res) {
+  return res.redirect(301, '/welcome');
+});
+app.get('/redirect-302', expressCacheOnDemand, function(req, res) {
+  return res.redirect(302, '/welcome');
+});
 
 app.listen(9765);
 
@@ -54,6 +60,39 @@ describe('expressCacheOnDemand', function() {
       done();
     });
   });
+  describe('handles redirects successfully with different statusCode', function() {
+    it('handles 301 statusCode', function(done){
+      return request('http://localhost:9765/redirect-301', { followRedirect: false }, function(err, response, body) {
+        assert(!err);
+        assert(response.statusCode === 301);
+        done();
+      });
+    });
+    it('handles 302 statusCode', function(done){
+      return request('http://localhost:9765/redirect-302', { followRedirect: false }, function(err, response, body) {
+        assert(!err);
+        assert(response.statusCode === 302);
+        done();
+      });
+    });
+    it('redirects to welcome from 301 statusCode', function(done){
+      return request('http://localhost:9765/redirect-301', { followRedirect: true }, function(err, response, body) {
+        assert(!err);
+        assert(response.statusCode === 200);
+        assert(body === 'URL was: /welcome, work count is: 9');
+        done();
+      });
+    });
+    it('redirects to welcome from 302 statusCode', function(done){
+      return request('http://localhost:9765/redirect-302', { followRedirect: true }, function(err, response, body) {
+        assert(!err);
+        assert(response.statusCode === 200);
+        assert(body === 'URL was: /welcome, work count is: 10');
+        done();
+      });
+    });
+
+  });
   it('replies to separate URLs with separate responses', function(done) {
     var i;
     var count = 0;
@@ -73,4 +112,3 @@ describe('expressCacheOnDemand', function() {
     }
   });
 });
-


### PR DESCRIPTION
It should be possible to assign different statusCode to redirects as in original spec:
http://expressjs.com/en/4x/api.html#res.redirect
for example: `res.redirect(301, path)`
